### PR TITLE
feat(lib): better error messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,8 @@ jobs:
       checks: write
       pull-requests: write
       contents: read
+    env:
+      RUSTFLAGS: ''
     steps:
       - name: Check out sources
         uses: actions/checkout@v4

--- a/c-explainer-cli/tests/cli_tests.rs
+++ b/c-explainer-cli/tests/cli_tests.rs
@@ -70,7 +70,7 @@ fn test_parse_error() {
     let mut c = spawn();
     c.exp_string("> ").unwrap();
     c.send_line("int x = 5;").unwrap();
-    c.exp_string("Error(s) parsing declaration:\r\nfound '=' expected '[', '(', or end of input")
+    c.exp_string("Error(s) parsing declaration:\r\nat 6..7: expected '[', '(', or end of input, but found '='")
         .unwrap();
     c.exp_string("> ").unwrap();
     kill(c);

--- a/c-explainer-cli/tests/cli_tests.rs
+++ b/c-explainer-cli/tests/cli_tests.rs
@@ -89,3 +89,14 @@ fn test_read_error() {
     println!("\"{out_str}\"");
     assert!(out_str.contains("Error reading line: stream did not contain valid UTF-8\n"));
 }
+
+#[test]
+fn test_print_license() {
+    let mut c = spawn();
+    c.exp_string("> ").unwrap();
+    c.send_line("@license").unwrap();
+    let output = c.exp_string("> ").unwrap();
+    kill(c);
+    assert!(output.contains("GNU General Public License"));
+    assert!(output.contains(env!("CARGO_PKG_REPOSITORY")));
+}

--- a/c-explainer/src/parser.rs
+++ b/c-explainer/src/parser.rs
@@ -111,8 +111,7 @@ pub fn parser<'src>()
         .labelled("type qualifier")
         .padded()
         .repeated()
-        .collect::<TypeQualifiers>()
-        .labelled("type qualifier list");
+        .collect::<TypeQualifiers>();
 
         let primitive_type = primitive_type_parser();
         let r#type = choice((
@@ -135,8 +134,7 @@ pub fn parser<'src>()
                 declarator
                     .clone()
                     .delimited_by(just('(').padded(), just(')').padded()),
-            ))
-            .labelled("declarator atom");
+            ));
 
             // Parses array declarator suffix. Returns `SuffixInfo`.
             let array_suffix = int(10)
@@ -198,7 +196,6 @@ pub fn parser<'src>()
             .then(declarator)
             .map(Declaration::from)
             .padded()
-            .labelled("declaration")
     })
 }
 

--- a/c-explainer/src/parser/error.rs
+++ b/c-explainer/src/parser/error.rs
@@ -1,0 +1,213 @@
+//! Parser error wrapper
+
+use core::{fmt::Display, ops::Deref};
+
+use chumsky::{
+    error::{Error as ChumskyError, Rich, RichPattern},
+    input::Input,
+    label::LabelError,
+    util::MaybeRef,
+};
+
+/// Wrapper newtype around [`Rich`] to provide a custom [`Display`] implementation.
+#[derive(Debug, Clone)]
+pub struct RichWrapper<'src>(Rich<'src, char>);
+
+impl<'src> From<Rich<'src, char>> for RichWrapper<'src> {
+    fn from(value: Rich<'src, char>) -> Self {
+        Self(value)
+    }
+}
+
+impl<'src> Deref for RichWrapper<'src> {
+    type Target = Rich<'src, char>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Display for RichWrapper<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "at {}: ", self.0.span())?;
+        match self.0.reason() {
+            chumsky::error::RichReason::ExpectedFound { expected, found } => {
+                write!(f, "expected ")?;
+                match expected.as_slice() {
+                    [] => write!(f, "[unknown]")?,
+                    [thing] => write!(f, "{}", thing.wrap())?,
+                    [a, b] => write!(f, "{} or {}", a.wrap(), b.wrap())?,
+                    [rest @ .., last] => {
+                        for thing in rest {
+                            write!(f, "{}, ", thing.wrap())?;
+                        }
+                        write!(f, "or {}", last.wrap())?;
+                    }
+                }
+                write!(f, ", but found ")?;
+                match found {
+                    Some(token) => write!(f, "'{}'", **token)?,
+                    None => write!(f, "end of input")?,
+                }
+            }
+            chumsky::error::RichReason::Custom(msg) => {
+                msg.fmt(f)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Type alias for the token type of a `&str` input.
+type StrToken<'src> = <&'src str as Input<'src>>::Token;
+
+/// Delegate [`LabelError`] to [`Rich`].
+impl<'src, L> LabelError<'src, &'src str, L> for RichWrapper<'src>
+where
+    L: Into<RichPattern<'src, StrToken<'src>>>,
+{
+    #[inline]
+    fn expected_found<E: IntoIterator<Item = L>>(
+        expected: E,
+        found: Option<MaybeRef<'src, StrToken>>,
+        span: <&'src str as Input<'src>>::Span,
+    ) -> Self {
+        let inner = <Rich<'src, char> as LabelError<'src, &'src str, L>>::expected_found(
+            expected, found, span,
+        );
+        Self(inner)
+    }
+
+    #[inline]
+    fn merge_expected_found<E: IntoIterator<Item = L>>(
+        self,
+        expected: E,
+        found: Option<MaybeRef<'src, StrToken<'src>>>,
+        span: <&'src str as Input<'src>>::Span,
+    ) -> Self
+    where
+        Self: ChumskyError<'src, &'src str>,
+    {
+        let inner = <Rich<'src, char> as LabelError<'src, &'src str, L>>::merge_expected_found(
+            self.0, expected, found, span,
+        );
+        Self(inner)
+    }
+
+    #[inline]
+    fn replace_expected_found<E: IntoIterator<Item = L>>(
+        self,
+        expected: E,
+        found: Option<MaybeRef<'src, <&'src str as Input<'src>>::Token>>,
+        span: <&'src str as Input<'src>>::Span,
+    ) -> Self {
+        let inner = <Rich<'src, char> as LabelError<'src, &'src str, L>>::replace_expected_found(
+            self.0, expected, found, span,
+        );
+        Self(inner)
+    }
+
+    #[inline]
+    fn label_with(&mut self, label: L) {
+        <Rich<'src, char> as LabelError<'src, &'src str, L>>::label_with(&mut self.0, label);
+    }
+
+    #[inline]
+    fn in_context(&mut self, _label: L, _span: <&'src str as Input<'src>>::Span) {
+        todo!("we don't use this function, so we don't implement it yet");
+        // <Rich<'src, char> as LabelError<'src, &'src str, L>>::in_context(&mut self.0, label, span);
+    }
+}
+
+/// Delegate [`Error`][ChumskyError] to [`Rich`].
+impl<'src> ChumskyError<'src, &'src str> for RichWrapper<'src> {
+    fn merge(self, other: Self) -> Self {
+        let inner = <Rich<'src, char> as ChumskyError<'src, &'src str>>::merge(self.0, other.0);
+        Self(inner)
+    }
+}
+
+/// Wrapper for [`RichPattern`] to provide a custom [`Display`] implementation.
+struct RichPatternWrapper<'src>(&'src RichPattern<'src, char>);
+
+impl Display for RichPatternWrapper<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match &self.0 {
+            RichPattern::Token(tok) => write!(f, "'{}'", **tok),
+            RichPattern::Label(l) => write!(f, "{l}"),
+            RichPattern::Identifier(i) => write!(f, "'{i}'"),
+            RichPattern::Any => write!(f, "anything"),
+            RichPattern::SomethingElse => write!(f, "something else"),
+            RichPattern::EndOfInput => write!(f, "end of input"),
+        }
+    }
+}
+
+/// Extension trait to provide a convenient `.wrap()` method on [`RichPattern`]s to wrap it with
+/// a [`RichPatternWrapper`].
+trait RichPatternExt {
+    fn wrap(&self) -> RichPatternWrapper<'_>;
+}
+
+impl RichPatternExt for RichPattern<'_, char> {
+    fn wrap(&self) -> RichPatternWrapper<'_> {
+        RichPatternWrapper(self)
+    }
+}
+
+/// Tests for the `RichWrapper` and `RichPatternWrapper` implementations.
+///
+/// These tests ensure that the custom `Display` implementations work as expected. Instead of
+/// constructing the errors directly, we just parse invalid inputs. This is less robust but much
+/// easier to maintain.
+#[cfg(test)]
+mod tests {
+    use alloc::string::ToString;
+    use chumsky::{Parser, label::LabelError};
+
+    use crate::parser::parser;
+
+    #[test]
+    fn expected_label() {
+        let errs = parser().parse(" ").into_errors();
+        assert_eq!(errs.len(), 1);
+        let err = errs.first().unwrap();
+        assert_eq!(
+            err.to_string(),
+            "at 1..1: expected type qualifier or type, but found end of input"
+        );
+    }
+
+    #[test]
+    fn expected_one_option() {
+        let errs = parser().parse("int foo[0").into_errors();
+        assert_eq!(errs.len(), 1);
+        let err = errs.first().unwrap();
+        assert_eq!(
+            err.to_string(),
+            "at 9..9: expected ']', but found end of input"
+        );
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "not yet implemented: we don't use this function, so we don't implement it yet"
+    )]
+    fn in_context() {
+        let mut errs = parser().parse("in").into_errors();
+        assert_eq!(errs.len(), 1);
+        let mut err = errs.swap_remove(0);
+        err.in_context("lkasjdf", (1..2).into());
+    }
+
+    #[test]
+    fn expected_anything() {
+        let errs = parser().parse("int f(").into_errors();
+        assert_eq!(errs.len(), 1);
+        let err = errs.first().unwrap();
+        assert_eq!(
+            err.to_string(),
+            "at 6..6: expected anything, function parameter, or ')', but found end of input"
+        );
+    }
+}


### PR DESCRIPTION
- Improves error message formatting.
- Removes some parser group labels to make it more clear what the next expected token is.